### PR TITLE
Revert "Use any 2 rule sets for passwords"

### DIFF
--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -7,10 +7,9 @@ from ckan.lib.navl.dictization_functions import Missing, Invalid
 
 
 MIN_PASSWORD_LENGTH = 10
-MIN_RULE_SETS = 2
 MIN_LEN_ERROR = (
     'Your password must be {} characters or longer, and consist of at least '
-    '{} of the following character sets: uppercase characters, lowercase '
+    'three of the following character sets: uppercase characters, lowercase '
     'characters, digits, punctuation & special characters.'
 )
 
@@ -32,8 +31,8 @@ def user_password_validator(key, data, errors, context):
             any(x.isdigit() for x in value),
             any(x in string.punctuation for x in value)
         ]
-        if len(value) < MIN_PASSWORD_LENGTH or sum(rules) < MIN_RULE_SETS:
-            raise Invalid(_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH, MIN_RULE_SETS)))
+        if len(value) < MIN_PASSWORD_LENGTH or sum(rules) < 3:
+            raise Invalid(_(MIN_LEN_ERROR.format(MIN_PASSWORD_LENGTH)))
 
 
 def old_username_validator(key, data, errors, context):


### PR DESCRIPTION
Reverts OpenGov-OpenData/ckanext-security#4 after testing.
@jguo144 I tried a password `1234567891O`, but got the following error

![issue_use any 2 rule sets for password](https://user-images.githubusercontent.com/12467641/38152150-4fa8b140-3434-11e8-85fb-6c796d76b7cc.png)

