### PR TITLE
Fix password reset bug

### DIFF
--- a/ckanext/security/controllers.py
+++ b/ckanext/security/controllers.py
@@ -36,7 +36,8 @@ class SecureUserController(UserController):
             id = request.params.get('user')
 
             context = {'model': model,
-                       'user': c.user}
+                       'user': c.user,
+                       'ignore_auth': True}
 
             data_dict = {'id': id}
             user_obj = None

--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -58,7 +58,7 @@ def user_about_validator(key, data, errors, context):
     else:
         pass
 
-invalid_list = ['hacked', 'hack[^a-zA-Z]+by', 'hacking', 'hacks']
+invalid_list = ['hacked', 'hacking', 'hacks', 'hack[^a-zA-Z]+', 'malware', 'virus']
 def is_input_valid(input_value):
     value = input_value.lower()
     pf = ProfanityFilter()


### PR DESCRIPTION
**Problem**
Users can not reset their password on /user/reset. The line [get_action('user_show')](https://github.com/OpenGov-OpenData/ckanext-security/blob/master/ckanext/security/controllers.py#L44) does a auth check for the user profiles. However, the user profiles have been set to be accessed only by logged in users. This means users who are not logged in can not reset their password.

**Fix**
Add ignore_auth context for password resets after the first auth check.
