### PR TITLE
Upgrade Profanity Check

### DIFF
--- a/ckanext/security/validators.py
+++ b/ckanext/security/validators.py
@@ -58,7 +58,7 @@ def user_about_validator(key, data, errors, context):
     else:
         pass
 
-invalid_list = ['hacked', 'hacking', 'hacks', 'hack[^a-zA-Z]+', 'malware', 'virus']
+invalid_list = ['hack', 'malware', 'virus']
 def is_input_valid(input_value):
     value = input_value.lower()
     pf = ProfanityFilter()


### PR DESCRIPTION
## Description
This is PR makes the profanity check so strict that any names contain `hack` will not pass validation. Users can not use a name like `evilhacker`,`thissiteishacked`,`happyhacking`, etc. It is noteworthy that in reality names can contain the work `hack`, such as `Diana Hacker`. An inevitable side effect of this PR is not allowing people like `Diana Hacker`to use their real names. However, before we find a good solution to distinguish usernames like `dianahacker` and `boringhacker`, we will lean towards the stricter side.

## Testing Procedure && Acceptance Criteria 
- Install this PR
- cannot use usernames that contains the word `hack`

## Submitter Checklist
- [x] I have applied the correct labels

## Reviewer Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. --->
<!--- If any of the following checkboxes don't apply, simply strike them out: ~~ ... ~~ --->
- [ ] I have run this code change locally
- [ ] I have addressed my questions about the code
- [ ] The description clearly states the impact of this code change.
- [ ] There is enough information to verify the functionality